### PR TITLE
make it possible to fully configure route middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+## [v0.4.0](https://github.com/cybex-gmbh/laravel-transmorpher-client/compare/v0.3.0...v0.4.0)
+
+> [!WARNING]
+> Breaking change!
+
+- Route middleware is now fully configurable
+  - the `web` middleware is no longer applied by default and has to be set in already published config files 
+
+
+
+

--- a/amigor/composer.lock
+++ b/amigor/composer.lock
@@ -137,11 +137,11 @@
         },
         {
             "name": "cybex/laravel-transmorpher-client",
-            "version": "dev-fix/css",
+            "version": "dev-feature/fully-configurable-route-middleware",
             "dist": {
                 "type": "path",
                 "url": "vendor/cybex/laravel-transmorpher-client",
-                "reference": "fe3a923a38759639a30fe3d4b53188197618d8ba"
+                "reference": "fc889a09e796c09f76d5178ed012d6ee2b57ddc4"
             },
             "require": {
                 "enyo/dropzone": "^5.9",

--- a/amigor/config/transmorpher.php
+++ b/amigor/config/transmorpher.php
@@ -5,7 +5,7 @@ return [
 
     // The middleware applied to routes provided by this package. The 'web' middleware is necessary and applied by default.
     'routeMiddleware' => [
-//        'auth'
+        'web'
     ],
 
     'api' => [

--- a/config/transmorpher.php
+++ b/config/transmorpher.php
@@ -3,8 +3,9 @@
 return [
     'client_name' => env('TRANSMORPHER_CLIENT_NAME'),
 
-    // The middleware applied to routes provided by this package. The 'web' middleware is necessary and applied by default.
+    // The middleware applied to routes provided by this package.
     'routeMiddleware' => [
+        'web',
         'auth'
     ],
 

--- a/src/TransmorpherServiceProvider.php
+++ b/src/TransmorpherServiceProvider.php
@@ -62,7 +62,7 @@ class TransmorpherServiceProvider extends ServiceProvider
     protected function registerRoutes(): void
     {
         Route::post(config('transmorpher.api.notifications_route'), ApiController::class)->name('transmorpherNotifications');
-        Route::middleware(array_merge(['web'], config('transmorpher.routeMiddleware', [])))->group(function () {
+        Route::middleware(config('transmorpher.routeMiddleware'))->group(function () {
             Route::post('transmorpher/{transmorpherMedia}/token', [UploadController::class, 'getUploadToken'])->name('transmorpherUploadToken');
             Route::post('transmorpher/handleUploadResponse/{transmorpherUpload}', [UploadController::class, 'handleUploadResponse'])->name('transmorpherHandleUploadResponse');
             Route::post('transmorpher/{transmorpherMedia}/state', [UploadStateController::class, 'getState'])->name('transmorpherState');


### PR DESCRIPTION
This is breaking as the `web` middleware is no longer applied by default.